### PR TITLE
fix: :bug: Escape Html Characters in string fields

### DIFF
--- a/src/data-helpers.js
+++ b/src/data-helpers.js
@@ -69,3 +69,13 @@ export const parseJson = (jsonString) => {
   // Parse the modified JSON string using the custom reviver function
   return JSON.parse(fixedJsonString, customReviver)
 }
+
+// This function escape HTML characters
+export const escapeHtml = (unsafe) => {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};

--- a/src/renderer/data-row.js
+++ b/src/renderer/data-row.js
@@ -1,4 +1,4 @@
-import { dataType } from "../data-helpers"
+import { dataType, escapeHtml } from "../data-helpers"
 
 const DataRow = function ({ key, value, expanded, indent, onToggleExpand, level = 0, parentRow }) {
   const row = document.createElement("div")
@@ -127,7 +127,7 @@ const DataRow = function ({ key, value, expanded, indent, onToggleExpand, level 
     valueWrapper.className = `value ${thisDataType.toLowerCase()}`
     valueEl = document.createElement("span")
     valueEl.className = "value-data"
-    valueEl.textContent = thisDataType === "string" ? `"${value}"` : value
+    valueEl.textContent = thisDataType === "string" ? `"${escapeHtml(value)}"` : value
     if (valueType) valueWrapper.appendChild(valueType)
     valueWrapper.appendChild(valueEl)
     keyValueWrapper.appendChild(valueWrapper)


### PR DESCRIPTION
Issue description:
Certain string fields were not properly escaping HTML special characters (<, >, &, ", ') when rendered or stored. This could lead to unexpected rendering behavior or potential XSS vulnerabilities.

Fix implemented:
Added HTML character escaping for all string fields displayed in the UI layer.
When rendering text values, reserved characters are now replaced by their corresponding HTML entities, ensuring safe and consistent output.